### PR TITLE
Feature M5Stack CoreS3 with USB ESP-NOW keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The project is still work in progress.
 
 Hardware (working):
 - ZX Spectrum with USB keyboard over ESP-NOW (wireless)
-  - [ESP32-S3-BOX](https://github.com/espressif/esp-box) as main emulator unit with display
+  - [ESP32-S3-BOX](https://github.com/espressif/esp-box) or [M5Stack CoreS3](https://shop.m5stack.com/products/) as main emulator unit with display
   - [ESP32-S3-USB-OTG](https://github.com/espressif/esp-bsp/tree/master/bsp/esp32_s3_usb_otg) as USB keyboard to ESP-NOW converter (wireless) (ESP-IDF)
 - ZX Spectrum PS/2 keyboard over UART (wired)
   - [M5Stack CoreS3](https://shop.m5stack.com/products/m5stack-cores3-esp32s3-lotdevelopment-kit) as main emulator unit with display
@@ -35,7 +35,7 @@ idf.py build flash monitor
 
 ### Assembly of the main part
 
-- connect ESP32-S3-BOX with USB-C to computer and flash the application
+- connect ESP32-S3-BOX or M5Stack CoreS3 with USB-C to computer and flash the application
 
 ## Software setup
 
@@ -51,11 +51,20 @@ cargo install espflash
 
 ## Run
 
-Flash and monitor the application:
+Flash and monitor the application.
+
+ESP32-S3-BOX:
 ```
 cd esp32-s3-box
 cargo run --release
 ```
+
+M5Stack CoreS3:
+```
+cd m5stack-cores3
+cargo run --release
+```
+
 
 ## ZX Spectrum PS/2 keyboard over UART (wired)
 
@@ -98,7 +107,7 @@ cargo install espflash
 
 Flash and monitor the application:
 ```
-cd m5stack-cores3
+cd m5stack-cores3-ps2-keyboard
 cargo run --release
 ```
 

--- a/m5stack-cores3-ps2-keyboard/.cargo/config.toml
+++ b/m5stack-cores3-ps2-keyboard/.cargo/config.toml
@@ -1,0 +1,23 @@
+[target.'cfg(target_arch = "xtensa")']
+runner = "espflash flash --monitor"
+rustflags = [
+  "-C", "link-arg=-Tlinkall.x",
+  #"-C", "link-arg=-Trom_functions.x",
+  "-C", "link-arg=-nostartfiles",
+]
+
+[build]
+# Uncomment the target if you'd like to use automatic code hinting in your IDE
+# target = "xtensa-esp32-none-elf"
+# target = "xtensa-esp32s2-none-elf"
+target = "xtensa-esp32s3-none-elf"
+# target = "riscv32imac-unknown-none-elf"
+
+[unstable]
+build-std = [ "core", "alloc" ]
+
+[env]
+# Use clean build after changing ESP_LOGLEVEL
+ESP_LOGLEVEL="TRACE"
+#ESP_LOGLEVEL="DEBUG"
+

--- a/m5stack-cores3-ps2-keyboard/Cargo.toml
+++ b/m5stack-cores3-ps2-keyboard/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "rustzx-m5stack-cores3"
+version = "2.0.0"
+authors = ["Juraj Michálek <juraj.michalek@gmail.com>"]
+edition = "2021"
+license = "MIT"
+
+[target.xtensa-esp32s3-none-elf.dependencies]
+hal = { package = "esp32s3-hal", version = "0.14.0" , optional = true }
+esp-backtrace = { version = "0.9.0", features = [
+    "esp32s3",
+    "panic-handler",
+    "print-uart",
+] }
+esp-println = { version = "0.8.0", features = ["esp32s3", "log"] }
+
+[dependencies]
+critical-section = { version = "1.1.2" }
+display-interface = "0.4"
+esp-alloc = "0.3.0"
+embedded-graphics = "0.8.0"
+embedded-hal = "0.2"
+embedded-graphics-framebuf = { version = "0.3.0", git = "https://github.com/georgik/embedded-graphics-framebuf.git", branch = "feature/embedded-graphics-0.8" }
+icm42670 = { git = "https://github.com/jessebraham/icm42670/" }
+log = "0.4"
+mipidsi = "0.7.1"
+#panic-halt = "0.2"
+shared-bus = { version = "0.3.0" }
+spooky-core = { git = "https://github.com/georgik/esp32-spooky-maze-game.git", rev = "fb5f755", default-features = false, features = ["static_maze"]}
+spooky-embedded = { git = "https://github.com/georgik/esp32-spooky-maze-game.git", rev = "fb5f755", default-features = false, features = [ "esp32s3", "static_maze", "resolution_320x240" ] }
+spi-dma-displayinterface = { git = "https://github.com/georgik/esp32-spooky-maze-game.git", rev = "fb5f755", features = ["esp32s3"] }
+#rustzx-utils = { version = "0.16.0" }
+#rustzx-core = { version = "0.16.0", features = ["embedded-roms"] }
+#rustzx-utils = { path = "../../rustzx/rustzx-utils" }
+#rustzx-core = { path = "../../rustzx/rustzx-core" , features = ["embedded-roms"] }
+rustzx-utils = { git = "https://github.com/georgik/rustzx.git", branch = "feature/performance-bounding-box" }
+rustzx-core = {  git = "https://github.com/georgik/rustzx.git", branch = "feature/performance-bounding-box", features = ["embedded-roms"] }
+axp2101 = { git = "https://github.com/georgik/axp2101-rs.git", rev = "60db0e1" }
+aw9523 = { git = "https://github.com/georgik/aw9523-rs.git", rev = "af49728" }
+pc-keyboard = "0.7.0"
+
+
+# Async dependencies
+embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }
+embassy-sync = { version = "0.5.0",optional = true }
+embassy-futures = { version = "0.1.0", optional = true }
+embassy-executor = { version = "0.4.0", package = "embassy-executor", features = ["nightly", "integrated-timers"], optional = true }
+embassy-time = { version = "0.2.0", optional = true }
+
+# WiFi dependencies
+#esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "a69545d", optional = true, features = [ "esp32c3", "esp-now", "async" ] }
+
+[features]
+#default = [ "hal", "embassy", "wifi"]
+default = [ "hal/psram-8m" ]
+embassy = [ "hal/psram-8m", "hal/embassy", "hal/async", "hal/embassy-time-timg0", "hal/rt", "hal/embassy-executor-thread", "embedded-hal-async", "embassy-sync", "embassy-futures", "embassy-executor", "embassy-time" ]
+#wifi = [ "esp-wifi" ]

--- a/m5stack-cores3-ps2-keyboard/src/host.rs
+++ b/m5stack-cores3-ps2-keyboard/src/host.rs
@@ -1,0 +1,131 @@
+
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+use embedded_graphics::pixelcolor::RgbColor;
+use log::*;
+
+use rustzx_core::host::FrameBuffer;
+use rustzx_core::host::FrameBufferSource;
+use rustzx_core::host::Host;
+use rustzx_core::host::HostContext;
+use rustzx_core::host::StubIoExtender;
+use rustzx_core::zx::video::colors::ZXBrightness;
+use rustzx_core::zx::video::colors::ZXColor;
+const LCD_H_RES: usize = 256;
+const LCD_PIXELS: usize = LCD_H_RES*192;
+use crate::stopwatch::InstantStopwatch;
+use crate::io::FileAsset;
+use embedded_graphics::pixelcolor::Rgb565;
+
+
+pub(crate) struct Esp32Host
+{
+}
+
+impl Host for Esp32Host
+{
+    type Context = Esp32HostContext;
+    type EmulationStopwatch = InstantStopwatch;
+    type FrameBuffer = EmbeddedGraphicsFrameBuffer;
+    type TapeAsset = FileAsset; // TODO
+    type IoExtender = StubIoExtender;
+    // type DebugInterface = StubDebugInterface; // TODO
+}
+
+pub(crate) struct Esp32HostContext;
+
+impl HostContext<Esp32Host> for Esp32HostContext
+{
+    fn frame_buffer_context(&self) -> <<Esp32Host as Host>::FrameBuffer as FrameBuffer>::Context {
+        ()
+    }
+}
+
+pub(crate) struct EmbeddedGraphicsFrameBuffer {
+    buffer: Vec<Rgb565>,
+    buffer_width: usize,
+    pub bounding_box_top_left: Option<(usize, usize)>,
+    pub bounding_box_bottom_right: Option<(usize, usize)>,
+}
+
+use crate::color_conv;
+impl EmbeddedGraphicsFrameBuffer {
+    // pub fn get_pixel_iter(&self) -> impl Iterator<Item = Rgb565> + '_ {
+    //     self.buffer.iter().copied()
+    // }
+
+    fn mark_dirty(&mut self, x: usize, y: usize) {
+        let (min_x, min_y) = self.bounding_box_top_left.unwrap_or((x, y));
+        let (max_x, max_y) = self.bounding_box_bottom_right.unwrap_or((x, y));
+
+        self.bounding_box_top_left = Some((min_x.min(x), min_y.min(y)));
+        self.bounding_box_bottom_right = Some((max_x.max(x), max_y.max(y)));
+    }
+
+    pub fn get_region_pixel_iter(&self, top_left: (usize, usize), bottom_right: (usize, usize)) -> impl Iterator<Item = Rgb565> + '_ {
+        let start_x = top_left.0;
+        let end_x = bottom_right.0 + 1; // Include the pixel at bottom_right coordinates
+        let start_y = top_left.1;
+        let end_y = bottom_right.1 + 1; // Include the pixel at bottom_right coordinates
+
+        (start_y..end_y).flat_map(move |y| {
+            (start_x..end_x).map(move |x| {
+                self.buffer[y * self.buffer_width + x]
+            })
+        })
+    }
+}
+
+
+impl FrameBuffer for EmbeddedGraphicsFrameBuffer {
+    type Context = ();
+
+    fn new(
+        width: usize,
+        height: usize,
+        source: FrameBufferSource,
+        _context: Self::Context,
+    ) -> Self {
+        info!("Allocation");
+        match source {
+            FrameBufferSource::Screen => {
+                info!("Allocating frame buffer width={}, height={}", width, height);
+
+                Self {
+                    buffer: vec![Rgb565::RED; LCD_PIXELS],
+                    buffer_width: LCD_H_RES as usize,
+                    bounding_box_bottom_right: None,
+                    bounding_box_top_left: None,
+                }
+            }
+            FrameBufferSource::Border => Self {
+                buffer: vec![Rgb565::WHITE; 1],
+                buffer_width: 1,
+                bounding_box_bottom_right: None,
+                bounding_box_top_left: None,
+            },
+        }
+    }
+
+
+    fn set_color(&mut self, x: usize, y: usize, zx_color: ZXColor, zx_brightness: ZXBrightness) {
+        let index = y * self.buffer_width + x;
+        let new_color = color_conv(&zx_color, zx_brightness);
+        if self.buffer[index] != new_color {
+            self.buffer[index] = new_color;
+            self.mark_dirty(x, y);  // Update the bounding box
+        }
+    }
+
+    fn set_colors(&mut self, x: usize, y: usize, colors: [ZXColor; 8], brightness: ZXBrightness) {
+        for (i, &color) in colors.iter().enumerate() {
+            self.set_color(x + i, y, color, brightness);
+        }
+    }
+
+    fn reset_bounding_box(&mut self) {
+        self.bounding_box_bottom_right = None;
+        self.bounding_box_top_left = None;
+    }
+
+}

--- a/m5stack-cores3-ps2-keyboard/src/io.rs
+++ b/m5stack-cores3-ps2-keyboard/src/io.rs
@@ -1,0 +1,53 @@
+// no_std implementation of File concept using memory buffer
+use rustzx_core::{
+    error::IoError,
+    host::{SeekableAsset, LoadableAsset, SeekFrom}
+    };
+
+#[derive(Debug)]
+pub enum FileAssetError {
+    ReadError,
+    SeekError,
+}
+
+pub struct FileAsset {
+    data: &'static [u8],
+    position: usize,
+}
+
+impl FileAsset {
+    pub fn new(data: &'static [u8]) -> Self {
+        FileAsset { data, position: 0 }
+    }
+
+    // Helper methods to convert FileAssetError to IoError if necessary
+    fn convert_error(error: FileAssetError) -> IoError {
+        match error {
+            FileAssetError::ReadError => IoError::HostAssetImplFailed,
+            FileAssetError::SeekError => IoError::SeekBeforeStart,
+        }
+    }
+}
+
+impl SeekableAsset for FileAsset {
+    fn seek(&mut self, _pos: SeekFrom) -> Result<usize, IoError> {
+        todo!()
+    }
+}
+
+impl LoadableAsset for FileAsset {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        let available = self.data.len() - self.position; // Bytes remaining
+        let to_read = available.min(buf.len()); // Number of bytes to read
+
+        if to_read == 0 {
+            return Err(FileAsset::convert_error(FileAssetError::ReadError));
+        }
+
+        buf[..to_read].copy_from_slice(&self.data[self.position..self.position + to_read]);
+        self.position += to_read; // Update the position
+
+        Ok(to_read) // Return the number of bytes read
+    }
+}
+

--- a/m5stack-cores3-ps2-keyboard/src/main.rs
+++ b/m5stack-cores3-ps2-keyboard/src/main.rs
@@ -1,0 +1,400 @@
+#![no_std]
+#![no_main]
+
+use spi_dma_displayinterface::spi_dma_displayinterface;
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_8X13, MonoTextStyle},
+    prelude::{Point, RgbColor},
+    text::Text,
+    Drawable,
+};
+
+use hal::{
+    clock::{ClockControl, CpuClock},
+    dma::DmaPriority,
+    gdma::Gdma,
+    i2c,
+    // interrupt,
+    peripherals::{
+        Peripherals,
+        UART1
+    },
+    prelude::*,
+    psram,
+    spi::{
+        master::{prelude::*, Spi},
+        SpiMode,
+    },
+    Delay,
+    // Rng,
+    IO,
+    uart::{
+        config::{Config, DataBits, Parity, StopBits},
+        TxRxPins,
+    },
+    Uart
+};
+
+// use spooky_embedded::app::app_loop;
+
+// use spooky_embedded::{
+    // embedded_display::LCD_MEMORY_SIZE,
+    // controllers::{accel::AccelMovementController, composites::accel_composite::AccelCompositeController}
+// };
+
+use esp_backtrace as _;
+
+// use icm42670::{Address, Icm42670};
+use shared_bus::BusManagerSimple;
+
+use rustzx_core::zx::video::colors::ZXBrightness;
+use rustzx_core::zx::video::colors::ZXColor;
+use rustzx_core::{zx::machine::ZXMachine, EmulationMode, Emulator, RustzxSettings, host::Host};
+
+use log::{info, error, debug};
+
+use core::time::Duration;
+use embedded_graphics::pixelcolor::Rgb565;
+
+use display_interface::WriteOnlyDataCommand;
+use mipidsi::models::Model;
+use embedded_hal::digital::v2::OutputPin;
+
+use axp2101::{ I2CPowerManagementInterface, Axp2101 };
+use aw9523::I2CGpioExpanderInterface;
+
+use pc_keyboard::{layouts, HandleControl, ScancodeSet2};
+
+mod host;
+mod stopwatch;
+mod io;
+mod pc_zxkey;
+use pc_zxkey::{ pc_code_to_zxkey, pc_code_to_modifier };
+mod zx_event;
+use zx_event::Event;
+
+use crate::io::FileAsset;
+
+#[global_allocator]
+static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
+
+const SCREEN_OFFSET_X: u16 = (320 - 256) / 2;
+const SCREEN_OFFSET_Y: u16 = (240 - 192) / 2;
+
+fn init_psram_heap() {
+    unsafe {
+        ALLOCATOR.init(psram::psram_vaddr_start() as *mut u8, psram::PSRAM_BYTES);
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take();
+
+    psram::init_psram(peripherals.PSRAM);
+    init_psram_heap();
+
+    let system = peripherals.SYSTEM.split();
+
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
+
+    esp_println::logger::init_logger_from_env();
+
+    let mut delay = Delay::new(&clocks);
+
+    info!("About to initialize the SPI LED driver");
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let lcd_sclk = io.pins.gpio36;
+    let lcd_mosi = io.pins.gpio37;
+    let lcd_cs = io.pins.gpio3;
+    let lcd_miso = io.pins.gpio6;
+    let lcd_dc = io.pins.gpio35.into_push_pull_output();
+    let lcd_reset = io.pins.gpio15.into_push_pull_output();
+
+    let serial_tx = io.pins.gpio17.into_push_pull_output();
+    let serial_rx = io.pins.gpio18.into_floating_input();
+
+    // I2C
+    let sda = io.pins.gpio12;
+    let scl = io.pins.gpio11;
+
+    let dma = Gdma::new(peripherals.DMA);
+    let dma_channel = dma.channel0;
+
+    let mut descriptors = [0u32; 8 * 3];
+    let mut rx_descriptors = [0u32; 8 * 3];
+
+    let i2c_bus = i2c::I2C::new(
+        peripherals.I2C0,
+        sda,
+        scl,
+        400u32.kHz(),
+        &clocks,
+    );
+
+    let bus = BusManagerSimple::new(i2c_bus);
+
+    info!("Initializing AXP2101");
+    let axp_interface = I2CPowerManagementInterface::new(bus.acquire_i2c());
+    let mut axp = Axp2101::new(axp_interface);
+    axp.init().unwrap();
+
+    info!("Initializing GPIO Expander");
+    let aw_interface = I2CGpioExpanderInterface::new(bus.acquire_i2c());
+    let mut aw = aw9523::Aw9523::new(aw_interface);
+    aw.init().unwrap();
+
+    // M5Stack CORE 2 - https://docs.m5stack.com/en/core/core2
+    // let mut backlight = io.pins.gpio3.into_push_pull_output();
+    delay.delay_ms(500u32);
+    info!("About to initialize the SPI LED driver");
+
+    let spi = Spi::new(
+        peripherals.SPI3,
+        60u32.MHz(),
+        SpiMode::Mode0,
+        &clocks,
+    ).with_pins(
+        Some(lcd_sclk),
+        Some(lcd_mosi),
+        Some(lcd_miso),
+        Some(lcd_cs),
+    ).with_dma(dma_channel.configure(
+        false,
+        &mut descriptors,
+        &mut rx_descriptors,
+        DmaPriority::Priority0,
+    ));
+
+    delay.delay_ms(500u32);
+
+    //https://github.com/m5stack/M5CoreS3/blob/main/src/utility/Config.h#L8
+    let di = spi_dma_displayinterface::new_no_cs(2*256*192, spi, lcd_dc);
+
+    let mut display = mipidsi::Builder::ili9342c_rgb565(di)
+        .with_display_size(320, 240)
+        .with_color_order(mipidsi::ColorOrder::Bgr)
+        .with_invert_colors(mipidsi::ColorInversion::Inverted)
+        .init(&mut delay, Some(lcd_reset))
+        .unwrap();
+    delay.delay_ms(500u32);
+    info!("Initializing...");
+    Text::new(
+        "Initializing...",
+        Point::new(80, 110),
+        MonoTextStyle::new(&FONT_8X13, RgbColor::WHITE),
+    )
+    .draw(&mut display)
+    .unwrap();
+
+    info!("Initialized");
+
+    // let mut rng = Rng::new(peripherals.RNG);
+    // let mut seed_buffer = [0u8; 32];
+    // rng.read(&mut seed_buffer).unwrap();
+
+    // let accel_movement_controller = AccelMovementController::new(icm, 0.2);
+    // let demo_movement_controller = spooky_core::demo_movement_controller::DemoMovementController::new(seed_buffer);
+    // let movement_controller = AccelCompositeController::new(demo_movement_controller, accel_movement_controller);
+    // use esp_wifi::{initialize, EspWifiInitFor};
+    // app_loop( &mut display, seed_buffer, movement_controller);
+    // info!("Initializing WiFi");
+    // use hal::Rng;
+    // #[cfg(target_arch = "xtensa")]
+    // let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    // #[cfg(target_arch = "riscv32")]
+    // let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    // match initialize(
+    //     EspWifiInitFor::Wifi,
+    //     timer,
+    //     Rng::new(peripherals.RNG),
+    //     system.radio_clock_control,
+    //     &clocks,
+    // ) {
+    //     Ok(_) => {
+    //         info!("WiFi initialized");
+    //     },
+    //     Err(err) => {
+    //         error!("Error initializing WiFi: {:?}", err);
+    //     }
+    // }
+
+
+    let config = Config {
+        baudrate: 115200,
+        data_bits: DataBits::DataBits8,
+        parity: Parity::ParityNone,
+        stop_bits: StopBits::STOP1,
+    };
+
+    let pins = TxRxPins::new_tx_rx(
+        serial_tx,
+        serial_rx,
+    );
+
+    let serial = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
+
+    let _ = app_loop(&mut display, color_conv, serial);
+    loop {}
+
+}
+
+const ZX_BLACK: Rgb565 = Rgb565::BLACK;
+const ZX_BRIGHT_BLUE: Rgb565 = Rgb565::new(0, 0, Rgb565::MAX_B);
+const ZX_BRIGHT_RED: Rgb565 = Rgb565::new(Rgb565::MAX_R, 0, 0);
+const ZX_BRIGHT_PURPLE: Rgb565 = Rgb565::new(Rgb565::MAX_R, 0, Rgb565::MAX_B);
+const ZX_BRIGHT_GREEN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G, 0);
+const ZX_BRIGHT_CYAN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G, Rgb565::MAX_B);
+const ZX_BRIGHT_YELLOW: Rgb565 = Rgb565::new(Rgb565::MAX_R, Rgb565::MAX_G, 0);
+const ZX_BRIGHT_WHITE: Rgb565 = Rgb565::WHITE;
+
+const ZX_NORMAL_BLUE: Rgb565 = Rgb565::new(0, 0, Rgb565::MAX_B / 2);
+const ZX_NORMAL_RED: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, 0, 0);
+const ZX_NORMAL_PURPLE: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, 0, Rgb565::MAX_B / 2);
+const ZX_NORMAL_GREEN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G / 2, 0);
+const ZX_NORMAL_CYAN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G / 2, Rgb565::MAX_B / 2);
+const ZX_NORMAL_YELLOW: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, Rgb565::MAX_G / 2, 0);
+const ZX_NORMAL_WHITE: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, Rgb565::MAX_G / 2, Rgb565::MAX_B / 2);
+
+fn color_conv(color: &ZXColor, brightness: ZXBrightness) -> Rgb565 {
+    match (color, brightness) {
+        (ZXColor::Black, _) => ZX_BLACK,
+
+        // Bright Colors
+        (ZXColor::Blue, ZXBrightness::Bright) => ZX_BRIGHT_BLUE,
+        (ZXColor::Red, ZXBrightness::Bright) => ZX_BRIGHT_RED,
+        (ZXColor::Purple, ZXBrightness::Bright) => ZX_BRIGHT_PURPLE,
+        (ZXColor::Green, ZXBrightness::Bright) => ZX_BRIGHT_GREEN,
+        (ZXColor::Cyan, ZXBrightness::Bright) => ZX_BRIGHT_CYAN,
+        (ZXColor::Yellow, ZXBrightness::Bright) => ZX_BRIGHT_YELLOW,
+        (ZXColor::White, ZXBrightness::Bright) => ZX_BRIGHT_WHITE,
+
+        // Normal Colors
+        (ZXColor::Blue, ZXBrightness::Normal) => ZX_NORMAL_BLUE,
+        (ZXColor::Red, ZXBrightness::Normal) => ZX_NORMAL_RED,
+        (ZXColor::Purple, ZXBrightness::Normal) => ZX_NORMAL_PURPLE,
+        (ZXColor::Green, ZXBrightness::Normal) => ZX_NORMAL_GREEN,
+        (ZXColor::Cyan, ZXBrightness::Normal) => ZX_NORMAL_CYAN,
+        (ZXColor::Yellow, ZXBrightness::Normal) => ZX_NORMAL_YELLOW,
+        (ZXColor::White, ZXBrightness::Normal) => ZX_NORMAL_WHITE,
+    }
+}
+
+fn handle_key_event<H: Host>(key: pc_keyboard::KeyCode, state: pc_keyboard::KeyState, emulator: &mut Emulator<H>) {
+    let is_pressed = matches!(state, pc_keyboard::KeyState::Down);
+    if let Some(mapped_key) = pc_code_to_zxkey(key, is_pressed).or_else(|| pc_code_to_modifier(key, is_pressed)) {
+        match mapped_key {
+            Event::ZXKey(k, p) => {
+                debug!("-> ZXKey");
+                emulator.send_key(k, p);
+            },
+            Event::NoEvent => {
+                error!("Key not implemented");
+            },
+            Event::ZXKeyWithModifier(k, k2, p) => {
+                debug!("-> ZXKeyWithModifier");
+                emulator.send_key(k, p);
+                emulator.send_key(k2, p);
+            }
+        }
+    } else {
+        info!("Mapped key: NoEvent");
+    }
+}
+
+fn app_loop<DI, M, RST>(
+    display: &mut mipidsi::Display<DI, M, RST>,
+    _color_conv: fn(&ZXColor, ZXBrightness) -> Rgb565,
+    mut serial: Uart<UART1>,
+) //-> Result<(), core::fmt::Error>
+where
+    DI: WriteOnlyDataCommand,
+    M: Model<ColorFormat = Rgb565>,
+    RST: OutputPin,
+{
+    // display
+    //     .clear(color_conv(ZXColor::Blue, ZXBrightness::Normal))
+    //     .map_err(|err| error!("{:?}", err))
+    //     .ok();
+
+    info!("Creating emulator");
+
+    let settings = RustzxSettings {
+        machine: ZXMachine::Sinclair128K,
+        // machine: ZXMachine::Sinclair48K,
+        emulation_mode: EmulationMode::FrameCount(1),
+        tape_fastload_enabled: true,
+        kempston_enabled: false,
+        mouse_enabled: false,
+        load_default_rom: true,
+    };
+
+    info!("Initialize emulator");
+    const MAX_FRAME_DURATION: Duration = Duration::from_millis(0);
+
+    let mut emulator: Emulator<host::Esp32Host> =
+        match Emulator::new(settings, host::Esp32HostContext {}) {
+            Ok(emulator) => emulator,
+            Err(err) => {
+                error!("Error creating emulator: {:?}", err);
+                return;
+            }
+        };
+
+
+
+    info!("Loading tape");
+    let tape_bytes = include_bytes!("../../data/hello.tap");
+    let tape_asset = FileAsset::new(tape_bytes);
+    let _ = emulator.load_tape(rustzx_core::host::Tape::Tap(tape_asset));
+
+    info!("Entering emulator loop");
+    let mut kb = pc_keyboard::Keyboard::new(
+        ScancodeSet2::new(),
+        layouts::Us104Key,
+        HandleControl::MapLettersToUnicode,
+    );
+
+    loop {
+        // info!("Emulating frame");
+        let read_result = serial.read();
+        match read_result {
+            Ok(byte) => {
+                match kb.add_byte(byte) {
+                    Ok(Some(event)) => {
+                        info!("Event {:?}", event);
+                        handle_key_event(event.code, event.state, &mut emulator);
+                    },
+                    Ok(None) => {},
+                    Err(_) => {},
+                }
+            }
+            Err(_) => {},
+        }
+
+        match emulator.emulate_frames(MAX_FRAME_DURATION) {
+            Ok(_) => {
+                let framebuffer = emulator.screen_buffer();
+                if let (Some(top_left), Some(bottom_right)) = (framebuffer.bounding_box_top_left, framebuffer.bounding_box_bottom_right) {
+                    // let width = bottom_right.0 - top_left.0 + 1; // Calculate width
+                    // let height = bottom_right.1 - top_left.1 + 1; // Calculate height
+                    // debug!("Bounding box: {:?} {:?}", top_left, bottom_right);
+                    // debug!("Bounding box size:  {}", width * height);
+                    let pixel_iterator = framebuffer.get_region_pixel_iter(top_left, bottom_right);
+                    let _ = display.set_pixels(
+                        top_left.0 as u16 + SCREEN_OFFSET_X,
+                        top_left.1 as u16 + SCREEN_OFFSET_Y,
+                        bottom_right.0 as u16 + SCREEN_OFFSET_X,
+                        bottom_right.1 as u16 + SCREEN_OFFSET_Y,
+                        pixel_iterator);
+                }
+                emulator.reset_bounding_box();
+
+            }
+            _ => {
+                error!("Emulation of frame failed");
+            }
+        }    }
+}

--- a/m5stack-cores3-ps2-keyboard/src/pc_zxkey.rs
+++ b/m5stack-cores3-ps2-keyboard/src/pc_zxkey.rs
@@ -1,0 +1,89 @@
+
+use rustzx_core::zx::keys::ZXKey;
+
+use crate::zx_event::Event;
+
+use pc_keyboard::KeyCode;
+
+pub(crate) fn pc_code_to_zxkey(keycode: KeyCode, pressed:bool) -> Option<Event> {
+    let zxkey_event:Option<ZXKey> = match keycode {
+        KeyCode::Spacebar => Some(ZXKey::Space),
+        KeyCode::Key1 => Some(ZXKey::N1),
+        KeyCode::Key2 => Some(ZXKey::N2),
+        KeyCode::Key3 => Some(ZXKey::N3),
+        KeyCode::Key4 => Some(ZXKey::N4),
+        KeyCode::Key5 => Some(ZXKey::N5),
+        KeyCode::Key6 => Some(ZXKey::N6),
+        KeyCode::Key7 => Some(ZXKey::N7),
+        KeyCode::Key8 => Some(ZXKey::N8),
+        KeyCode::Key9 => Some(ZXKey::N9),
+        KeyCode::Key0 => Some(ZXKey::N0),
+        KeyCode::Q => Some(ZXKey::Q),
+        KeyCode::W => Some(ZXKey::W),
+        KeyCode::E => Some(ZXKey::E),
+        KeyCode::R => Some(ZXKey::R),
+        KeyCode::T => Some(ZXKey::T),
+        KeyCode::Y => Some(ZXKey::Y),
+        KeyCode::U => Some(ZXKey::U),
+        KeyCode::I => Some(ZXKey::I),
+        KeyCode::O => Some(ZXKey::O),
+        KeyCode::P => Some(ZXKey::P),
+        KeyCode::A => Some(ZXKey::A),
+        KeyCode::S => Some(ZXKey::S),
+        KeyCode::D => Some(ZXKey::D),
+        KeyCode::F => Some(ZXKey::F),
+        KeyCode::G => Some(ZXKey::G),
+        KeyCode::H => Some(ZXKey::H),
+        KeyCode::J => Some(ZXKey::J),
+        KeyCode::K => Some(ZXKey::K),
+        KeyCode::L => Some(ZXKey::L),
+        KeyCode::Z => Some(ZXKey::Z),
+        KeyCode::X => Some(ZXKey::X),
+        KeyCode::C => Some(ZXKey::C),
+        KeyCode::V => Some(ZXKey::V),
+        KeyCode::B => Some(ZXKey::B),
+        KeyCode::N => Some(ZXKey::N),
+        KeyCode::M => Some(ZXKey::M),
+
+        KeyCode::LShift => Some(ZXKey::Shift),
+        KeyCode::RShift => Some(ZXKey::Shift),
+
+        KeyCode::LAlt => Some(ZXKey::SymShift),
+        KeyCode::RAlt2 => Some(ZXKey::SymShift),
+        KeyCode::LControl => Some(ZXKey::SymShift),
+        KeyCode::RControl => Some(ZXKey::SymShift),
+
+        KeyCode::Return => Some(ZXKey::Enter),
+
+        _ => None,
+    };
+
+    return zxkey_event.map(|k| Event::ZXKey(k, pressed))
+}
+
+pub (crate) fn pc_code_to_modifier(keycode: KeyCode, pressed: bool) -> Option<Event> {
+    let zxkey_event:Option<(ZXKey, ZXKey)> = match keycode {
+        KeyCode::Backspace => Some((ZXKey::Shift, ZXKey::N0)),
+
+        KeyCode::ArrowLeft => Some((ZXKey::Shift, ZXKey::N5)),
+        KeyCode::ArrowDown => Some((ZXKey::Shift, ZXKey::N6)),
+        KeyCode::ArrowUp => Some((ZXKey::Shift, ZXKey::N7)),
+        KeyCode::ArrowRight => Some((ZXKey::Shift, ZXKey::N8)),
+
+        // ========= Row 2 (the numbers) =========
+        KeyCode::OemMinus => Some((ZXKey::SymShift, ZXKey::J)), // -
+        KeyCode::OemPlus => Some((ZXKey::SymShift, ZXKey::K)), // +
+
+        // ========= Row 4 (ASDF) =========
+        KeyCode::Oem1 => Some((ZXKey::SymShift, ZXKey::O)), // ;
+        // KeyCode::Oem3 => Some((ZXKey::SymShift, ZXKey::Z)), // :
+        KeyCode::Oem3 => Some((ZXKey::SymShift, ZXKey::N7)), // '
+
+        // ========= Row 5 (ZXCV) =========
+        KeyCode::OemComma => Some((ZXKey::SymShift, ZXKey::N)), // ,
+        KeyCode::OemPeriod => Some((ZXKey::SymShift, ZXKey::M)), // .
+        KeyCode::Oem2 => Some((ZXKey::SymShift, ZXKey::V)), // /
+        _ => None,
+    };
+    zxkey_event.map(|(k, k2)| Event::ZXKeyWithModifier(k, k2, pressed))
+}

--- a/m5stack-cores3-ps2-keyboard/src/stopwatch.rs
+++ b/m5stack-cores3-ps2-keyboard/src/stopwatch.rs
@@ -1,0 +1,26 @@
+use rustzx_core::host::Stopwatch;
+// use std::time::{Duration, Instant};
+use core::time::Duration;
+
+pub struct InstantStopwatch {
+    // timestamp: Instant,
+}
+
+impl Default for InstantStopwatch {
+    fn default() -> Self {
+        Self {
+            // timestamp: Instant::now(),
+        }
+    }
+}
+
+impl Stopwatch for InstantStopwatch {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn measure(&self) -> Duration {
+        // self.timestamp.elapsed()
+        Duration::from_millis(100)
+    }
+}

--- a/m5stack-cores3-ps2-keyboard/src/zx_event.rs
+++ b/m5stack-cores3-ps2-keyboard/src/zx_event.rs
@@ -1,0 +1,22 @@
+use rustzx_core::{zx::keys::ZXKey};
+
+pub enum Event {
+    NoEvent,
+    ZXKey(ZXKey, bool),
+    ZXKeyWithModifier(ZXKey, ZXKey, bool),
+    // CompoundKey(CompoundKey, bool),
+    // Kempston(KempstonKey, bool),
+    // Sinclair(SinclairJoyNum, SinclairKey, bool),
+    // MouseMove { x: i8, y: i8 },
+    // MouseButton(KempstonMouseButton, bool),
+    // MouseWheel(KempstonMouseWheelDirection),
+    // SwitchFrameTrace,
+    // ChangeJoyKeyboardLayer(bool),
+    // ChangeSpeed(EmulationMode),
+    // InsertTape,
+    // StopTape,
+    // QuickSave,
+    // QuickLoad,
+    // OpenFile(PathBuf),
+    // Exit,
+}

--- a/m5stack-cores3/.cargo/config.toml
+++ b/m5stack-cores3/.cargo/config.toml
@@ -2,7 +2,7 @@
 runner = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
-  #"-C", "link-arg=-Trom_functions.x",
+  "-C", "link-arg=-Trom_functions.x",
   "-C", "link-arg=-nostartfiles",
 ]
 

--- a/m5stack-cores3/.cargo/config.toml
+++ b/m5stack-cores3/.cargo/config.toml
@@ -18,6 +18,6 @@ build-std = [ "core", "alloc" ]
 
 [env]
 # Use clean build after changing ESP_LOGLEVEL
-ESP_LOGLEVEL="TRACE"
-#ESP_LOGLEVEL="DEBUG"
+#ESP_LOGLEVEL="TRACE"
+ESP_LOGLEVEL="DEBUG"
 

--- a/m5stack-cores3/Cargo.toml
+++ b/m5stack-cores3/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 
 [target.xtensa-esp32s3-none-elf.dependencies]
-hal = { package = "esp32s3-hal", version = "0.14.0" , optional = true }
+hal = { package = "esp32s3-hal", version = "0.14.0" , features = ["embassy", "async", "embassy-time-timg0", "rt", "embassy-executor-thread", "opsram-8m"] }
 esp-backtrace = { version = "0.9.0", features = [
     "esp32s3",
     "panic-handler",
@@ -18,6 +18,13 @@ esp-println = { version = "0.8.0", features = ["esp32s3", "log"] }
 critical-section = { version = "1.1.2" }
 display-interface = "0.4"
 esp-alloc = "0.3.0"
+
+embassy-sync = { version = "0.5.0" }
+embassy-futures = { version = "0.1.0" }
+embassy-net = { version = "0.2.1", features = ["tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-executor = { version = "0.4.0", package = "embassy-executor", features = ["nightly", "integrated-timers"] }
+embassy-time = { version = "0.2.0" }
+
 embedded-graphics = "0.8.0"
 embedded-hal = "0.2"
 embedded-graphics-framebuf = { version = "0.3.0", git = "https://github.com/georgik/embedded-graphics-framebuf.git", branch = "feature/embedded-graphics-0.8" }
@@ -38,20 +45,12 @@ rustzx-core = {  git = "https://github.com/georgik/rustzx.git", branch = "featur
 axp2101 = { git = "https://github.com/georgik/axp2101-rs.git", rev = "60db0e1" }
 aw9523 = { git = "https://github.com/georgik/aw9523-rs.git", rev = "af49728" }
 pc-keyboard = "0.7.0"
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "a69545d", features = [ "esp32s3", "esp-now", "async", "phy-enable-usb" ] }
 
-
-# Async dependencies
-embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }
-embassy-sync = { version = "0.5.0",optional = true }
-embassy-futures = { version = "0.1.0", optional = true }
-embassy-executor = { version = "0.4.0", package = "embassy-executor", features = ["nightly", "integrated-timers"], optional = true }
-embassy-time = { version = "0.2.0", optional = true }
-
-# WiFi dependencies
-#esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", rev = "a69545d", optional = true, features = [ "esp32c3", "esp-now", "async" ] }
-
-[features]
-#default = [ "hal", "embassy", "wifi"]
-default = [ "hal/psram-8m" ]
-embassy = [ "hal/psram-8m", "hal/embassy", "hal/async", "hal/embassy-time-timg0", "hal/rt", "hal/embassy-executor-thread", "embedded-hal-async", "embassy-sync", "embassy-futures", "embassy-executor", "embassy-time" ]
-#wifi = [ "esp-wifi" ]
+[patch.crates-io]
+embassy-net = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-net", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-time", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-executor", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-executor-macros = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-executor-macros", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-sync", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-futures", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}

--- a/m5stack-cores3/Cargo.toml
+++ b/m5stack-cores3/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 
 [target.xtensa-esp32s3-none-elf.dependencies]
-hal = { package = "esp32s3-hal", version = "0.14.0" , features = ["embassy", "async", "embassy-time-timg0", "rt", "embassy-executor-thread", "opsram-8m"] }
+hal = { package = "esp32s3-hal", version = "0.14.0" , features = ["embassy", "async", "embassy-time-timg0", "rt", "embassy-executor-thread", "psram-8m"] }
 esp-backtrace = { version = "0.9.0", features = [
     "esp32s3",
     "panic-handler",

--- a/m5stack-cores3/src/main.rs
+++ b/m5stack-cores3/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![feature(type_alias_impl_trait)]
 
 use spi_dma_displayinterface::spi_dma_displayinterface;
 
@@ -86,7 +87,7 @@ fn init_psram_heap() {
     }
 }
 
-#[entry]
+#[main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
 
@@ -94,8 +95,6 @@ async fn main(spawner: Spawner) -> ! {
     init_psram_heap();
 
     let system = peripherals.SYSTEM.split();
-
-    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     esp_println::logger::init_logger_from_env();
 
@@ -268,7 +267,6 @@ async fn app_loop()
     let mut delay = Delay::new(&clocks);
 
     info!("About to initialize the SPI LED driver");
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let lcd_sclk = io.pins.gpio36;
     let lcd_mosi = io.pins.gpio37;

--- a/m5stack-cores3/src/main.rs
+++ b/m5stack-cores3/src/main.rs
@@ -36,12 +36,6 @@ use hal::{
     Uart
 };
 
-// use spooky_embedded::app::app_loop;
-
-// use spooky_embedded::{
-    // embedded_display::LCD_MEMORY_SIZE,
-    // controllers::{accel::AccelMovementController, composites::accel_composite::AccelCompositeController}
-// };
 
 use esp_backtrace as _;
 
@@ -89,7 +83,7 @@ fn init_psram_heap() {
 }
 
 #[entry]
-fn main() -> ! {
+async fn main(spawner: Spawner) -> ! {
     let peripherals = Peripherals::take();
 
     psram::init_psram(peripherals.PSRAM);
@@ -100,6 +94,174 @@ fn main() -> ! {
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     esp_println::logger::init_logger_from_env();
+
+
+
+    info!("Starting up");
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
+    let embassy_timer = hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks).timer0;
+    embassy::init(&clocks, embassy_timer);
+    spawner.spawn(app_loop()).unwrap();
+    spawner.spawn(esp_now_receiver()).unwrap();
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        info!("Tick");
+        ticker.next().await;
+    }
+
+}
+
+const ZX_BLACK: Rgb565 = Rgb565::BLACK;
+const ZX_BRIGHT_BLUE: Rgb565 = Rgb565::new(0, 0, Rgb565::MAX_B);
+const ZX_BRIGHT_RED: Rgb565 = Rgb565::new(Rgb565::MAX_R, 0, 0);
+const ZX_BRIGHT_PURPLE: Rgb565 = Rgb565::new(Rgb565::MAX_R, 0, Rgb565::MAX_B);
+const ZX_BRIGHT_GREEN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G, 0);
+const ZX_BRIGHT_CYAN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G, Rgb565::MAX_B);
+const ZX_BRIGHT_YELLOW: Rgb565 = Rgb565::new(Rgb565::MAX_R, Rgb565::MAX_G, 0);
+const ZX_BRIGHT_WHITE: Rgb565 = Rgb565::WHITE;
+
+const ZX_NORMAL_BLUE: Rgb565 = Rgb565::new(0, 0, Rgb565::MAX_B / 2);
+const ZX_NORMAL_RED: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, 0, 0);
+const ZX_NORMAL_PURPLE: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, 0, Rgb565::MAX_B / 2);
+const ZX_NORMAL_GREEN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G / 2, 0);
+const ZX_NORMAL_CYAN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G / 2, Rgb565::MAX_B / 2);
+const ZX_NORMAL_YELLOW: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, Rgb565::MAX_G / 2, 0);
+const ZX_NORMAL_WHITE: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, Rgb565::MAX_G / 2, Rgb565::MAX_B / 2);
+
+fn color_conv(color: &ZXColor, brightness: ZXBrightness) -> Rgb565 {
+    match (color, brightness) {
+        (ZXColor::Black, _) => ZX_BLACK,
+
+        // Bright Colors
+        (ZXColor::Blue, ZXBrightness::Bright) => ZX_BRIGHT_BLUE,
+        (ZXColor::Red, ZXBrightness::Bright) => ZX_BRIGHT_RED,
+        (ZXColor::Purple, ZXBrightness::Bright) => ZX_BRIGHT_PURPLE,
+        (ZXColor::Green, ZXBrightness::Bright) => ZX_BRIGHT_GREEN,
+        (ZXColor::Cyan, ZXBrightness::Bright) => ZX_BRIGHT_CYAN,
+        (ZXColor::Yellow, ZXBrightness::Bright) => ZX_BRIGHT_YELLOW,
+        (ZXColor::White, ZXBrightness::Bright) => ZX_BRIGHT_WHITE,
+
+        // Normal Colors
+        (ZXColor::Blue, ZXBrightness::Normal) => ZX_NORMAL_BLUE,
+        (ZXColor::Red, ZXBrightness::Normal) => ZX_NORMAL_RED,
+        (ZXColor::Purple, ZXBrightness::Normal) => ZX_NORMAL_PURPLE,
+        (ZXColor::Green, ZXBrightness::Normal) => ZX_NORMAL_GREEN,
+        (ZXColor::Cyan, ZXBrightness::Normal) => ZX_NORMAL_CYAN,
+        (ZXColor::Yellow, ZXBrightness::Normal) => ZX_NORMAL_YELLOW,
+        (ZXColor::White, ZXBrightness::Normal) => ZX_NORMAL_WHITE,
+    }
+}
+
+
+fn handle_key_event<H: Host>(key_state: u8, modifier: u8, key_code:u8, emulator: &mut Emulator<H>) {
+    let is_pressed = key_state == 1;
+    if let Some(mapped_key) = usb_code_to_zxkey(key_code, is_pressed).or_else(|| usb_code_to_modifier(key_code, is_pressed)) {
+        match mapped_key {
+            Event::ZXKey(k, p) => {
+                debug!("-> ZXKey");
+                emulator.send_key(k, p);
+            },
+            Event::NoEvent => {
+                error!("Key not implemented");
+            },
+            Event::ZXKeyWithModifier(k, k2, p) => {
+                debug!("-> ZXKeyWithModifier");
+                emulator.send_key(k, p);
+                emulator.send_key(k2, p);
+            }
+        }
+    } else {
+        info!("Mapped key: NoEvent");
+    }
+}
+
+
+const ESP_NOW_PAYLOAD_INDEX: usize = 20;
+
+#[embassy_executor::task]
+async fn esp_now_receiver() {
+    info!("ESP-NOW receiver task");
+    let peripherals = unsafe { Peripherals::steal() };
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
+    let wifi_timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    let rng = Rng::new(peripherals.RNG);
+    let radio_clock_control = system.radio_clock_control;
+
+
+    let wifi = peripherals.WIFI;
+
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        wifi_timer,
+        rng,
+        radio_clock_control,
+        &clocks,
+    );
+
+    match init {
+        Ok(init) => {
+            info!("ESP-NOW init");
+            let mut esp_now = EspNow::new(&init, wifi);
+            match esp_now {
+                Ok(mut esp_now) => {
+                    let peer_info = PeerInfo {
+                        // Specify a unique peer address here (replace with actual address)
+                        peer_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+                        lmk: None,
+                        channel: Some(1), // Specify the channel if known
+                        encrypt: false, // Set to true if encryption is needed
+                    };
+
+                    // Check if the peer already exists
+                    if !esp_now.peer_exists(&peer_info.peer_address) {
+                        info!("Adding peer");
+                        match esp_now.add_peer(peer_info) {
+                            Ok(_) => info!("Peer added"),
+                            Err(e) => error!("Peer add error: {:?}", e),
+                        }
+                    } else {
+                        info!("Peer already exists, not adding");
+                    }
+
+                    loop {
+                        let received_data = esp_now.receive();
+                        match received_data {
+                            Some(data) => {
+                                let bytes = data.data;
+                                info!("Key code received over ESP-NOW: state = {:?}, modifier = {:?}, key = {:?}", bytes[ESP_NOW_PAYLOAD_INDEX], bytes[ESP_NOW_PAYLOAD_INDEX + 1], bytes[ESP_NOW_PAYLOAD_INDEX + 2]);
+                                let bytes_written = PIPE.write(&[bytes[ESP_NOW_PAYLOAD_INDEX], bytes[ESP_NOW_PAYLOAD_INDEX + 1], bytes[ESP_NOW_PAYLOAD_INDEX + 2]]).await;
+                                if bytes_written != 3 {
+                                    error!("Failed to write to pipe");
+                                    break;
+                                }
+                            }
+                            None => {
+                                //error!("ESP-NOW receive error");
+                            }
+                        }
+                        Timer::after(Duration::from_millis(5)).await;
+                    }
+                }
+                Err(e) => error!("ESP-NOW initialization error: {:?}", e),
+            }
+        }
+        Err(e) => error!("WiFi initialization error: {:?}", e),
+    }
+}
+
+
+#[embassy_executor::task]
+async fn app_loop()
+{
+
+    Timer::after(Duration::from_millis(1500)).await;
+
+    let peripherals = unsafe { Peripherals::steal() };
+    let system = peripherals.SYSTEM.split();
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let mut delay = Delay::new(&clocks);
 
@@ -112,9 +274,6 @@ fn main() -> ! {
     let lcd_miso = io.pins.gpio6;
     let lcd_dc = io.pins.gpio35.into_push_pull_output();
     let lcd_reset = io.pins.gpio15.into_push_pull_output();
-
-    let serial_tx = io.pins.gpio17.into_push_pull_output();
-    let serial_rx = io.pins.gpio18.into_floating_input();
 
     // I2C
     let sda = io.pins.gpio12;
@@ -190,134 +349,6 @@ fn main() -> ! {
     .unwrap();
 
     info!("Initialized");
-
-    // let mut rng = Rng::new(peripherals.RNG);
-    // let mut seed_buffer = [0u8; 32];
-    // rng.read(&mut seed_buffer).unwrap();
-
-    // let accel_movement_controller = AccelMovementController::new(icm, 0.2);
-    // let demo_movement_controller = spooky_core::demo_movement_controller::DemoMovementController::new(seed_buffer);
-    // let movement_controller = AccelCompositeController::new(demo_movement_controller, accel_movement_controller);
-    // use esp_wifi::{initialize, EspWifiInitFor};
-    // app_loop( &mut display, seed_buffer, movement_controller);
-    // info!("Initializing WiFi");
-    // use hal::Rng;
-    // #[cfg(target_arch = "xtensa")]
-    // let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
-    // #[cfg(target_arch = "riscv32")]
-    // let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    // match initialize(
-    //     EspWifiInitFor::Wifi,
-    //     timer,
-    //     Rng::new(peripherals.RNG),
-    //     system.radio_clock_control,
-    //     &clocks,
-    // ) {
-    //     Ok(_) => {
-    //         info!("WiFi initialized");
-    //     },
-    //     Err(err) => {
-    //         error!("Error initializing WiFi: {:?}", err);
-    //     }
-    // }
-
-
-    let config = Config {
-        baudrate: 115200,
-        data_bits: DataBits::DataBits8,
-        parity: Parity::ParityNone,
-        stop_bits: StopBits::STOP1,
-    };
-
-    let pins = TxRxPins::new_tx_rx(
-        serial_tx,
-        serial_rx,
-    );
-
-    let serial = Uart::new_with_config(peripherals.UART1, config, Some(pins), &clocks);
-
-    let _ = app_loop(&mut display, color_conv, serial);
-    loop {}
-
-}
-
-const ZX_BLACK: Rgb565 = Rgb565::BLACK;
-const ZX_BRIGHT_BLUE: Rgb565 = Rgb565::new(0, 0, Rgb565::MAX_B);
-const ZX_BRIGHT_RED: Rgb565 = Rgb565::new(Rgb565::MAX_R, 0, 0);
-const ZX_BRIGHT_PURPLE: Rgb565 = Rgb565::new(Rgb565::MAX_R, 0, Rgb565::MAX_B);
-const ZX_BRIGHT_GREEN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G, 0);
-const ZX_BRIGHT_CYAN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G, Rgb565::MAX_B);
-const ZX_BRIGHT_YELLOW: Rgb565 = Rgb565::new(Rgb565::MAX_R, Rgb565::MAX_G, 0);
-const ZX_BRIGHT_WHITE: Rgb565 = Rgb565::WHITE;
-
-const ZX_NORMAL_BLUE: Rgb565 = Rgb565::new(0, 0, Rgb565::MAX_B / 2);
-const ZX_NORMAL_RED: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, 0, 0);
-const ZX_NORMAL_PURPLE: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, 0, Rgb565::MAX_B / 2);
-const ZX_NORMAL_GREEN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G / 2, 0);
-const ZX_NORMAL_CYAN: Rgb565 = Rgb565::new(0, Rgb565::MAX_G / 2, Rgb565::MAX_B / 2);
-const ZX_NORMAL_YELLOW: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, Rgb565::MAX_G / 2, 0);
-const ZX_NORMAL_WHITE: Rgb565 = Rgb565::new(Rgb565::MAX_R / 2, Rgb565::MAX_G / 2, Rgb565::MAX_B / 2);
-
-fn color_conv(color: &ZXColor, brightness: ZXBrightness) -> Rgb565 {
-    match (color, brightness) {
-        (ZXColor::Black, _) => ZX_BLACK,
-
-        // Bright Colors
-        (ZXColor::Blue, ZXBrightness::Bright) => ZX_BRIGHT_BLUE,
-        (ZXColor::Red, ZXBrightness::Bright) => ZX_BRIGHT_RED,
-        (ZXColor::Purple, ZXBrightness::Bright) => ZX_BRIGHT_PURPLE,
-        (ZXColor::Green, ZXBrightness::Bright) => ZX_BRIGHT_GREEN,
-        (ZXColor::Cyan, ZXBrightness::Bright) => ZX_BRIGHT_CYAN,
-        (ZXColor::Yellow, ZXBrightness::Bright) => ZX_BRIGHT_YELLOW,
-        (ZXColor::White, ZXBrightness::Bright) => ZX_BRIGHT_WHITE,
-
-        // Normal Colors
-        (ZXColor::Blue, ZXBrightness::Normal) => ZX_NORMAL_BLUE,
-        (ZXColor::Red, ZXBrightness::Normal) => ZX_NORMAL_RED,
-        (ZXColor::Purple, ZXBrightness::Normal) => ZX_NORMAL_PURPLE,
-        (ZXColor::Green, ZXBrightness::Normal) => ZX_NORMAL_GREEN,
-        (ZXColor::Cyan, ZXBrightness::Normal) => ZX_NORMAL_CYAN,
-        (ZXColor::Yellow, ZXBrightness::Normal) => ZX_NORMAL_YELLOW,
-        (ZXColor::White, ZXBrightness::Normal) => ZX_NORMAL_WHITE,
-    }
-}
-
-fn handle_key_event<H: Host>(key: pc_keyboard::KeyCode, state: pc_keyboard::KeyState, emulator: &mut Emulator<H>) {
-    let is_pressed = matches!(state, pc_keyboard::KeyState::Down);
-    if let Some(mapped_key) = pc_code_to_zxkey(key, is_pressed).or_else(|| pc_code_to_modifier(key, is_pressed)) {
-        match mapped_key {
-            Event::ZXKey(k, p) => {
-                debug!("-> ZXKey");
-                emulator.send_key(k, p);
-            },
-            Event::NoEvent => {
-                error!("Key not implemented");
-            },
-            Event::ZXKeyWithModifier(k, k2, p) => {
-                debug!("-> ZXKeyWithModifier");
-                emulator.send_key(k, p);
-                emulator.send_key(k2, p);
-            }
-        }
-    } else {
-        info!("Mapped key: NoEvent");
-    }
-}
-
-fn app_loop<DI, M, RST>(
-    display: &mut mipidsi::Display<DI, M, RST>,
-    _color_conv: fn(&ZXColor, ZXBrightness) -> Rgb565,
-    mut serial: Uart<UART1>,
-) //-> Result<(), core::fmt::Error>
-where
-    DI: WriteOnlyDataCommand,
-    M: Model<ColorFormat = Rgb565>,
-    RST: OutputPin,
-{
-    // display
-    //     .clear(color_conv(ZXColor::Blue, ZXBrightness::Normal))
-    //     .map_err(|err| error!("{:?}", err))
-    //     .ok();
 
     info!("Creating emulator");
 
@@ -396,5 +427,8 @@ where
             _ => {
                 error!("Emulation of frame failed");
             }
-        }    }
+        }
+
+        Timer::after(Duration::from_millis(5)).await;
+    }
 }


### PR DESCRIPTION
- PS/2 keyboard support moved to m5stack-cores3-ps2-keyboard
- m5stack-cores3 modified to use USB keyboard with ESP-NOW sender from ESP32-S3-USB-OTG
- code is duplicated